### PR TITLE
GMail SMTP Syntax error fix. Added method to return list of emails only ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,19 @@ Here is how to use this package to send a basic mail message.
     msg.Body = "plain text body"
     smtp.SendMail(addr, auth, msg.From.String(), msg.Recipients(), msg.Bytes())
 
+## Edge Cases
+
+When sending emails through GMail SMTP servers, if you run into an error like:
+
+    555 5.5.2 Syntax error. z6sm27198953bkn.8 - gsmtp
+
+Try changing the smtp.SendMail call in order to provide only the email addresses (without full names)
+
+	smtp.SendMail(addr, auth, msg.From.Address, msg.RecipientsEmails(), msg.Bytes())
+
 ## License
 
 The ezmail code is free to use and distribute, under the [MIT license](https://github.com/marcw/ezmail/blob/master/LICENSE).
 
 [![Build Status](https://travis-ci.org/marcw/ezmail.png?branch=master)](https://travis-ci.org/marcw/ezmail)
+

--- a/mail.go
+++ b/mail.go
@@ -78,11 +78,21 @@ func (msg *Message) String() string {
 	return string(msg.Bytes())
 }
 
-// Returns list of recipients needed by net/smtp SendMail function
+// Returns list of recipients (Format: "Recipient Name <recipientemail@example.com>")
 func (msg *Message) Recipients() []string {
 	var r []string
 	for _, v := range msg.To {
 		r = append(r, v.String())
+	}
+
+	return r
+}
+
+// Returns list of recipient email addresses
+func (msg *Message) RecipientsEmails() []string {
+	var r []string
+	for _, v := range msg.To {
+		r = append(r, v.Address)
 	}
 
 	return r


### PR DESCRIPTION
This should resolve #2 . Also updated the docs
